### PR TITLE
Sping 2.7.x Autoconfiguration

### DIFF
--- a/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/ServiceConfiguration.java
+++ b/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/ServiceConfiguration.java
@@ -6,6 +6,10 @@ package io.redlink.geocoding.nominatim;
 import java.util.Map;
 import java.util.Objects;
 
+import static io.redlink.geocoding.nominatim.NominatimGeocoder.DEFAULT_GEOCODE_ENDPOINT;
+import static io.redlink.geocoding.nominatim.NominatimGeocoder.DEFAULT_LOOKUP_ENDPOINT;
+import static io.redlink.geocoding.nominatim.NominatimGeocoder.DEFAULT_REVERSE_ENDPOINT;
+
 class ServiceConfiguration {
 
     private final String geocodeEndpoint;
@@ -16,7 +20,7 @@ class ServiceConfiguration {
     private final Map<String, String> customHeaders;
 
     ServiceConfiguration() {
-        this(NominatimGeocoder.DEFAULT_GEOCODE_ENDPOINT, NominatimGeocoder.DEFAULT_REVERSE_ENDPOINT, NominatimGeocoder.DEFAULT_LOOKUP_ENDPOINT, Map.of(), Map.of());
+        this(DEFAULT_GEOCODE_ENDPOINT, DEFAULT_REVERSE_ENDPOINT, DEFAULT_LOOKUP_ENDPOINT, Map.of(), Map.of());
     }
 
     ServiceConfiguration(String geocodeEndpoint, String reverseEndpoint, String lookupEndpoint,
@@ -30,15 +34,15 @@ class ServiceConfiguration {
     }
 
     public String getGeocodeEndpoint() {
-        return Objects.requireNonNullElse(geocodeEndpoint, NominatimGeocoder.DEFAULT_GEOCODE_ENDPOINT);
+        return Objects.requireNonNullElse(geocodeEndpoint, DEFAULT_GEOCODE_ENDPOINT);
     }
 
     public String getReverseEndpoint() {
-        return Objects.requireNonNullElse(reverseEndpoint, NominatimGeocoder.DEFAULT_REVERSE_ENDPOINT);
+        return Objects.requireNonNullElse(reverseEndpoint, DEFAULT_REVERSE_ENDPOINT);
     }
 
     public String getLookupEndpoint() {
-        return Objects.requireNonNullElse(lookupEndpoint, NominatimGeocoder.DEFAULT_LOOKUP_ENDPOINT);
+        return Objects.requireNonNullElse(lookupEndpoint, DEFAULT_LOOKUP_ENDPOINT);
     }
 
     public Map<String, String> getCustomQueryParams() {

--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,11 @@
                         <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.8</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/proxy/client/src/test/java/io/redlink/geocoding/proxy/ProxyGeocoderTest.java
+++ b/proxy/client/src/test/java/io/redlink/geocoding/proxy/ProxyGeocoderTest.java
@@ -121,8 +121,8 @@ class ProxyGeocoderTest {
     void testLookup() throws IOException {
         Assertions.assertThat(geocoder.lookup(RandomStringUtils.randomAlphabetic(8)))
                 .as("Lookup Result")
-                .isPresent().get()
-                .isEqualTo(place1);
+                .isPresent()
+                .contains(place1);
 
         Assertions.assertThat(geocoder.lookup("does-not-exist"))
                 .as("Lookup Result")

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/CachedGeocodingAutoconfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/CachedGeocodingAutoconfiguration.java
@@ -21,14 +21,13 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
@@ -36,16 +35,15 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  */
-@Configuration
-@ConditionalOnClass(CachingGeocoder.class)
-@ConditionalOnBean(Geocoder.class)
-@EnableConfigurationProperties(GeocodingProperties.class)
-@Conditional(CachedGeocodingAutoconfiguration.CacheConfigurationCondition.class)
-@AutoConfigureAfter({
+@AutoConfiguration(after = {
         GoogleGeocodingAutoConfiguration.class,
         NominatimGeocodingAutoConfiguration.class,
         ProxyGeocodingAutoConfiguration.class,
 })
+@ConditionalOnClass(CachingGeocoder.class)
+@ConditionalOnBean(Geocoder.class)
+@Conditional(CachedGeocodingAutoconfiguration.CacheConfigurationCondition.class)
+@EnableConfigurationProperties(GeocodingProperties.class)
 public class CachedGeocodingAutoconfiguration extends GeocodingAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(CachedGeocodingAutoconfiguration.class);

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GoogleGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GoogleGeocodingAutoConfiguration.java
@@ -22,13 +22,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
@@ -36,7 +36,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  */
-@Configuration
+@AutoConfiguration
 @ConditionalOnMissingBean(Geocoder.class)
 @ConditionalOnClass(GoogleMapsGeocoder.class)
 @Conditional(GoogleGeocodingAutoConfiguration.GoogleMapsCondition.class)

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
@@ -21,21 +21,19 @@ import io.redlink.geocoding.nominatim.NominatimGeocoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
 /**
  */
-@Configuration
+@AutoConfiguration(after = GoogleGeocodingAutoConfiguration.class)
 @ConditionalOnClass(NominatimGeocoder.class)
 @ConditionalOnMissingBean(Geocoder.class)
 @EnableConfigurationProperties(GeocodingProperties.class)
-@AutoConfigureAfter({GoogleGeocodingAutoConfiguration.class})
 public class NominatimGeocodingAutoConfiguration extends GeocodingAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(NominatimGeocodingAutoConfiguration.class);

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/ProxyGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/ProxyGeocodingAutoConfiguration.java
@@ -22,14 +22,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ConfigurationCondition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
@@ -37,12 +36,14 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
  */
-@Configuration
+@AutoConfiguration(after = {
+        GoogleGeocodingAutoConfiguration.class,
+        NominatimGeocodingAutoConfiguration.class,
+})
 @ConditionalOnClass(ProxyGeocoder.class)
 @ConditionalOnMissingBean(Geocoder.class)
 @Conditional(ProxyGeocodingAutoConfiguration.ProxyGeocoderCondition.class)
 @EnableConfigurationProperties(GeocodingProperties.class)
-@AutoConfigureAfter({GoogleGeocodingAutoConfiguration.class, NominatimGeocodingAutoConfiguration.class})
 public class ProxyGeocodingAutoConfiguration extends GeocodingAutoConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(ProxyGeocodingAutoConfiguration.class);

--- a/spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,4 @@
+io.redlink.geocoding.spring.boot.autoconfigure.GoogleGeocodingAutoConfiguration
+io.redlink.geocoding.spring.boot.autoconfigure.NominatimGeocodingAutoConfiguration
+io.redlink.geocoding.spring.boot.autoconfigure.ProxyGeocodingAutoConfiguration
+io.redlink.geocoding.spring.boot.autoconfigure.CachedGeocodingAutoconfiguration

--- a/spring-boot/src/test/java/CachedGeocoderTest.java
+++ b/spring-boot/src/test/java/CachedGeocoderTest.java
@@ -36,6 +36,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ActiveProfiles("cache")
 @EnableAutoConfiguration
 class CachedGeocoderTest {
+    // NOTE: see https://docs.spring.io/spring-boot/docs/2.7.15/reference/htmlsingle/#features.developing-auto-configuration.testing
+    //       on how to properly test autoconfiguration
 
     private final Geocoder geocoder;
 

--- a/spring-boot/src/test/java/GoogleGeocoderTest.java
+++ b/spring-boot/src/test/java/GoogleGeocoderTest.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ActiveProfiles("google")
 @EnableAutoConfiguration
 class GoogleGeocoderTest {
+    // NOTE: see https://docs.spring.io/spring-boot/docs/2.7.15/reference/htmlsingle/#features.developing-auto-configuration.testing
+    //       on how to properly test autoconfiguration
 
     private final Geocoder geocoder;
 

--- a/spring-boot/src/test/java/NominatimGeocoderTest.java
+++ b/spring-boot/src/test/java/NominatimGeocoderTest.java
@@ -35,6 +35,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ActiveProfiles("nominatim")
 @EnableAutoConfiguration
 class NominatimGeocoderTest {
+    // NOTE: see https://docs.spring.io/spring-boot/docs/2.7.15/reference/htmlsingle/#features.developing-auto-configuration.testing
+    //       on how to properly test autoconfiguration
 
     private final Geocoder geocoder;
 


### PR DESCRIPTION
In `2.7.x`, spring-boot switched to a different mechanism to register autoconfigurations:

They are now listed in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`

The old way (`META-INF/spring.factories`) will stop working in spring-boot `3.x`.