### PR TITLE
Fixed Priorities of Autoconfig: ProxyGeocoder was never selected

### DIFF
--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GoogleGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GoogleGeocodingAutoConfiguration.java
@@ -51,7 +51,7 @@ public class GoogleGeocodingAutoConfiguration extends GeocodingAutoConfiguration
 
     @Bean(name = "googleGeocoder")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public Geocoder google() {
+    public GoogleMapsGeocoder google() {
         final GeocodingProperties.GoogleMapsProperties google = properties.getGoogle();
 
         final GoogleMapsBuilder googleMapsBuilder = GoogleMapsGeocoder.builder();

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
@@ -30,7 +30,10 @@ import org.springframework.context.annotation.Scope;
 
 /**
  */
-@AutoConfiguration(after = GoogleGeocodingAutoConfiguration.class)
+@AutoConfiguration(after = {
+        GoogleGeocodingAutoConfiguration.class,
+        ProxyGeocodingAutoConfiguration.class,
+})
 @ConditionalOnClass(NominatimGeocoder.class)
 @ConditionalOnMissingBean(Geocoder.class)
 @EnableConfigurationProperties(GeocodingProperties.class)
@@ -44,7 +47,7 @@ public class NominatimGeocodingAutoConfiguration extends GeocodingAutoConfigurat
 
     @Bean(name = "nominatimGeocoder")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public Geocoder nominatim() {
+    public NominatimGeocoder nominatim() {
         final GeocodingProperties.NominatimProperties nominatim = properties.getNominatim();
 
         final NominatimBuilder nominatimBuilder = NominatimGeocoder.builder()

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/ProxyGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/ProxyGeocodingAutoConfiguration.java
@@ -38,7 +38,6 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
  */
 @AutoConfiguration(after = {
         GoogleGeocodingAutoConfiguration.class,
-        NominatimGeocodingAutoConfiguration.class,
 })
 @ConditionalOnClass(ProxyGeocoder.class)
 @ConditionalOnMissingBean(Geocoder.class)
@@ -54,7 +53,7 @@ public class ProxyGeocodingAutoConfiguration extends GeocodingAutoConfiguration 
 
     @Bean(name = "proxyGeocoder")
     @Scope(ConfigurableBeanFactory.SCOPE_SINGLETON)
-    public Geocoder nominatim() {
+    public ProxyGeocoder proxyGeocoder() {
         final GeocodingProperties.ProxyProperties proxyProperties = properties.getProxyService();
 
         final ProxyBuilder proxyBuilder = ProxyGeocoder.builder()

--- a/spring-boot/src/test/java/CachedGeocoderTest.java
+++ b/spring-boot/src/test/java/CachedGeocoderTest.java
@@ -52,7 +52,7 @@ class CachedGeocoderTest {
     }
 
     @Test
-    void testType() throws Exception {
+    void testType() {
         assertThat(geocoder)
                 .as("CachingGeocoder expected")
                 .isInstanceOf(CachingGeocoder.class);

--- a/spring-boot/src/test/java/NominatimGeocoderTest.java
+++ b/spring-boot/src/test/java/NominatimGeocoderTest.java
@@ -51,7 +51,7 @@ class NominatimGeocoderTest {
     }
 
     @Test
-    void testType() throws Exception {
+    void testType() {
         assertThat(geocoder)
                 .as("NominatimGeocoder expected")
                 .isInstanceOf(NominatimGeocoder.class);

--- a/spring-boot/src/test/java/ProxyGeocoderTest.java
+++ b/spring-boot/src/test/java/ProxyGeocoderTest.java
@@ -15,7 +15,7 @@
  */
 
 import io.redlink.geocoding.Geocoder;
-import io.redlink.geocoding.google.GoogleMapsGeocoder;
+import io.redlink.geocoding.proxy.ProxyGeocoder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,16 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(initializers = ConfigDataApplicationContextInitializer.class)
-@ActiveProfiles("google")
+@ActiveProfiles("proxy")
 @EnableAutoConfiguration
-class GoogleGeocoderTest {
+class ProxyGeocoderTest {
     // NOTE: see https://docs.spring.io/spring-boot/docs/2.7.15/reference/htmlsingle/#features.developing-auto-configuration.testing
     //       on how to properly test autoconfiguration
 
     private final Geocoder geocoder;
 
     @Autowired
-    GoogleGeocoderTest(Geocoder geocoder) {
+    ProxyGeocoderTest(Geocoder geocoder) {
         this.geocoder = geocoder;
     }
 
@@ -53,7 +53,7 @@ class GoogleGeocoderTest {
     @Test
     void testType() {
         assertThat(geocoder)
-                .as("GoogleGeocoder expected")
-                .isInstanceOf(GoogleMapsGeocoder.class);
+                .as("ProxyGeocoderTest expected")
+                .isInstanceOf(ProxyGeocoder.class);
     }
 }

--- a/spring-boot/src/test/resources/application-nominatim.properties
+++ b/spring-boot/src/test/resources/application-nominatim.properties
@@ -1,1 +1,1 @@
-geocoding.nominatim.base-url = http://www.example.com
+geocoding.nominatim.base-url = https://www.example.com

--- a/spring-boot/src/test/resources/application-proxy.properties
+++ b/spring-boot/src/test/resources/application-proxy.properties
@@ -1,0 +1,1 @@
+geocoding.proxy-service.base-url = https://www.example.com:8008


### PR DESCRIPTION
Fixed the priorities of the autoconfig:
1. `GoogleMapsGeocoder` (if credentials are provided)
2. `ProxyGeocoder` (if base-url is provided)
3. `NominatimGeocoder` (with default to the public OpenStreetMaps server)
4. Wrapping a `CachedGeocoder` around (if cache-timeout is provided)

Previously it was not possible to get a `ProxyGeocoder` using Autoconfiguration (was overruled by `NominatimGeocoder`)