### PR TITLE
Improve compliance with OpenStreetMaps "Nominatim Usage Policy"

### DIFF
--- a/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/NominatimGeocoder.java
+++ b/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/NominatimGeocoder.java
@@ -135,9 +135,10 @@ public class NominatimGeocoder implements Geocoder {
         this.email = email;
         this.proxy = proxy;
         this.serviceConfiguration = serviceConfiguration;
-        if (maxQps < 0 && StringUtils.equals(baseUrl, PUBLIC_NOMINATIM_SERVER)) {
+        if (StringUtils.equals(baseUrl, PUBLIC_NOMINATIM_SERVER)) {
             // set default qps for public server
-            maxQps = 1;
+            maxQps = Math.max(maxQps, 1);
+            LOG.info("Initialize NominatimGeocoder using public server at {}; Data from OpenStreetMap (see https://openstreetmap.org/copyright)", baseUrl);
         }
         if (maxQps > 0) {
             rateLimiter = RateLimiter.create(maxQps);
@@ -344,6 +345,7 @@ public class NominatimGeocoder implements Geocoder {
             rateLimiter.acquire();
         }
         final HttpClientBuilder builder = HttpClients.custom();
+        builder.setUserAgent(serviceConfiguration.getUserAgent());
         if (proxy == null || proxy.type() == Proxy.Type.DIRECT) {
             LOG.trace("Direct Connection");
         } else if (proxy.type() == Proxy.Type.HTTP) {

--- a/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/NominatimGeocoder.java
+++ b/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/NominatimGeocoder.java
@@ -136,9 +136,10 @@ public class NominatimGeocoder implements Geocoder {
         this.proxy = proxy;
         this.serviceConfiguration = serviceConfiguration;
         if (StringUtils.equals(baseUrl, PUBLIC_NOMINATIM_SERVER)) {
+            LOG.info("Initialize NominatimGeocoder using public server at {}; " +
+                     "Data © OpenStreetMap contributors, ODbL 1.0. https://osm.org/copyright)", baseUrl);
             // set default qps for public server
             maxQps = Math.max(maxQps, 1);
-            LOG.info("Initialize NominatimGeocoder using public server at {}; Data from OpenStreetMap (see https://openstreetmap.org/copyright)", baseUrl);
         }
         if (maxQps > 0) {
             rateLimiter = RateLimiter.create(maxQps);

--- a/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/ServiceConfiguration.java
+++ b/openstreetmap/src/main/java/io/redlink/geocoding/nominatim/ServiceConfiguration.java
@@ -19,18 +19,22 @@ class ServiceConfiguration {
     private final Map<String, String> customQueryParams;
     private final Map<String, String> customHeaders;
 
+    private final String userAgent;
+
     ServiceConfiguration() {
-        this(DEFAULT_GEOCODE_ENDPOINT, DEFAULT_REVERSE_ENDPOINT, DEFAULT_LOOKUP_ENDPOINT, Map.of(), Map.of());
+        this(DEFAULT_GEOCODE_ENDPOINT, DEFAULT_REVERSE_ENDPOINT, DEFAULT_LOOKUP_ENDPOINT, Map.of(), Map.of(), null);
     }
 
     ServiceConfiguration(String geocodeEndpoint, String reverseEndpoint, String lookupEndpoint,
-                                Map<String, String> customQueryParams,
-                                Map<String, String> customHeaders) {
+                         Map<String, String> customQueryParams,
+                         Map<String, String> customHeaders,
+                         String userAgent) {
         this.geocodeEndpoint = geocodeEndpoint;
         this.reverseEndpoint = reverseEndpoint;
         this.lookupEndpoint = lookupEndpoint;
         this.customQueryParams = Map.copyOf(customQueryParams);
         this.customHeaders = Map.copyOf(customHeaders);
+        this.userAgent = userAgent;
     }
 
     public String getGeocodeEndpoint() {
@@ -52,4 +56,9 @@ class ServiceConfiguration {
     public Map<String, String> getCustomHeaders() {
         return customHeaders;
     }
+
+    public String getUserAgent() {
+        return userAgent;
+    }
+
 }

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GeocodingProperties.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/GeocodingProperties.java
@@ -92,6 +92,8 @@ public class GeocodingProperties {
 
         private String email;
 
+        private String userAgentString;
+
         private Map<String, String> extraQueryParams = Map.of();
 
         private Map<String, String> extraHeaders = Map.of();
@@ -120,6 +122,15 @@ public class GeocodingProperties {
 
         public NominatimProperties setEmail(String email) {
             this.email = email;
+            return this;
+        }
+
+        public String getUserAgentString() {
+            return userAgentString;
+        }
+
+        public NominatimProperties setUserAgentString(String userAgentString) {
+            this.userAgentString = userAgentString;
             return this;
         }
 

--- a/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
+++ b/spring-boot/src/main/java/io/redlink/geocoding/spring/boot/autoconfigure/NominatimGeocodingAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Scope;
 
 /**
+ *
  */
 @AutoConfiguration(after = {
         GoogleGeocodingAutoConfiguration.class,
@@ -51,7 +52,8 @@ public class NominatimGeocodingAutoConfiguration extends GeocodingAutoConfigurat
         final GeocodingProperties.NominatimProperties nominatim = properties.getNominatim();
 
         final NominatimBuilder nominatimBuilder = NominatimGeocoder.builder()
-                    .setEmail(nominatim.getEmail());
+                .setEmail(nominatim.getEmail())
+                .setUserAgent(nominatim.getUserAgentString());
 
         if (nominatim.getBaseUrl() != null) {
             nominatimBuilder.setBaseUrl(nominatim.getBaseUrl());


### PR DESCRIPTION
## Improve compliance with OpenStreetMaps "Nominatim Usage Policy"

### Provide a meaningful User-Agent
> `redlink-geocoding/${version} (io.redlink.geocoding.osm; +https://github.com/redlink-gmbh/redlink-geocoding)`
### Add attribution 
As LOG-Statement on `INFO`-Level:
> `Initialize NominatimGeocoder using public server at https://nominatim.openstreetmap.org/; Data from OpenStreetMap (see https://openstreetmap.org/copyright)`